### PR TITLE
No need for sudo on the lxc version check

### DIFF
--- a/lib/linecook/util/config.rb
+++ b/lib/linecook/util/config.rb
@@ -115,7 +115,7 @@ module Linecook
     end
 
     def check_lxc
-      version = `sudo lxc-info --version`
+      version = `lxc-info --version`
       fail "lxc too old (<#{LXC_MIN_VERSION}) or not present" unless Gem::Version.new(version) >= Gem::Version.new(LXC_MIN_VERSION)
     end
 


### PR DESCRIPTION
The `sudo` part causes a failure on amibuilder 

```
sudo: no tty present and no askpass program specified
/u/apps/cloud-scripts/shared/bundle/ruby/2.1.0/gems/linecook-gem-0.5.9/lib/linecook/util/config.rb:119:in `check_lxc': lxc too old (<1.1.4) or not present (RuntimeError)
```

Theres no need for `sudo` here

```
niko@cloudbot0.svc.use1.isrv.io:/u/apps/cloud-scripts/shared/log $ lxc-info --version
1.1.5
```

@dalehamel