### PR TITLE
Only support xvd device notation

### DIFF
--- a/lib/linecook-gem/packager/packer.rb
+++ b/lib/linecook-gem/packager/packer.rb
@@ -190,7 +190,7 @@ module Linecook
     end
 
     def device_prefix
-      prefixes = ['xvd', 'sd']
+      prefixes = ['xvd']
       `sudo ls -1 /sys/block`.lines.each do |dev| # FIXME
         prefixes.each do |prefix|
           return prefix if dev =~ /^#{prefix}/


### PR DESCRIPTION
@graemej @mutemule for review

I *think* this should work-around the drive enumeration issue caused by the secure kernel showing 'sd' devices and get our ami builds working again

cc @xthexder 