### PR TITLE
Simplify packer EBS provisioning using the new 'from scratch' option

### DIFF
--- a/lib/linecook-gem/baker.rb
+++ b/lib/linecook-gem/baker.rb
@@ -4,6 +4,7 @@ require 'kitchen'
 require 'kitchen/command/test'
 
 require 'linecook-gem/image'
+require 'linecook-gem/util/common'
 require 'linecook-gem/baker/docker'
 
 module Linecook
@@ -13,12 +14,9 @@ module Linecook
       def initialize(image, directory: nil)
         @directory = File.expand_path(directory || Dir.pwd)
         @image = image
-
-        Dir.chdir(@directory) do
-          load_config
-          munge_config
-          @driver = driver
-        end
+        @config = load_config
+        munge_config
+        @driver = driver
 
       end
 
@@ -78,21 +76,6 @@ module Linecook
           @driver.exec('rm -rf /etc/chef')
           @driver.exec('rm -rf /tmp/kitchen')
           @driver.exec('rm -f /etc/sudoers.d/kitchen')
-        end
-      end
-
-      def load_config
-        @config ||= begin
-
-          Kitchen::Config.new(
-            kitchen_root: @directory,
-            loader: Kitchen::Loader::YAML.new(
-              project_config: ENV['KITCHEN_YAML'] || File.join(@directory, '.kitchen.yml'),
-              local_config: ENV['KITCHEN_LOCAL_YAML'],
-              global_config: ENV['KITCHEN_GLOBAL_YAML']
-            )
-          )
-
         end
       end
 

--- a/lib/linecook-gem/cli.rb
+++ b/lib/linecook-gem/cli.rb
@@ -50,13 +50,14 @@ class Image < Thor
 
   desc 'package', 'Package image'
   method_option :name, type: :string, required: true, banner: 'NAME', desc: 'Name of the image to package.', aliases: '-n'
+  method_option :directory, type: :string, required: false, banner: 'DIR', desc: 'Directory containing kitchen files', aliases: '-d'
   method_option :tag, type: :string, default: 'latest', banner: 'NAME', desc: 'Tag of the image to package.', aliases: '-t'
   method_option :group, type: :string, required: false, banner: 'ID', desc: 'Group of image to package', aliases: '-g'
   method_option :strategy, type: :string, default: 'packer', banner: 'STRATEGY', enum: ['packer', 'squashfs'], desc: 'Packaging strategy', aliases: '-s'
   def package
     opts = options.symbolize_keys
     image = Linecook::Image.new(opts[:name], opts[:group], opts[:tag])
-    Linecook::Packager.package(image, name: opts[:strategy])
+    Linecook::Packager.package(image, name: opts[:strategy], directory: opts[:directory])
   end
 
   desc 'save', 'Save running build'

--- a/lib/linecook-gem/packager.rb
+++ b/lib/linecook-gem/packager.rb
@@ -9,9 +9,9 @@ module Linecook
   module Packager
     extend self
 
-    def package(image, name: 'packer')
+    def package(image, name: 'packer', directory: nil)
       image.fetch
-      provider(name.to_sym).package(image)
+      provider(name.to_sym).package(image, directory)
     end
 
   private

--- a/lib/linecook-gem/util/common.rb
+++ b/lib/linecook-gem/util/common.rb
@@ -1,3 +1,23 @@
+require 'kitchen'
+
+def load_config(directory)
+  @config ||= begin
+    Dir.chdir(directory) do
+      Kitchen::Config.new(
+        kitchen_root: Dir.pwd,
+        loader: Kitchen::Loader::YAML.new(
+          project_config: ENV['KITCHEN_YAML'] || File.join(Dir.pwd, '.kitchen.yml'),
+          local_config: ENV['KITCHEN_LOCAL_YAML'],
+          global_config: ENV['KITCHEN_GLOBAL_YAML']
+        )
+      )
+
+    end
+  end
+end
+
+
+
 def with_retries(retries, sleep_duration: 5, &block)
   attempts = 0
   while attempts < retries


### PR DESCRIPTION
# Why

Packer 0.12.0 (as of 0.11.0) supports a new "from_scratch" option to chroot based builds. This allows us to get rid of the hacks and gymnastics that we did to support chroot based builds on top of an existing ami. We've fundamentally always been using the "from_scratch" strategy, only now it is officially supported, and this allows us to simplify the implementation a lot.

In addition to this, we can now easily pass specific packaging parameters in to packer. For example, adding the following to a kitchen suite:

```
packager:
  builder:
    ami_block_device_mappings:
      - device_name: xvdf
        ...etc
```

This will expose the full power of the packer ebs builder to a user of linecook.

# How

We use from_scratch strategy, and the pre_mount and post_mount commands to do all of the necessary setup. This eliminates a great deal of code, including code that was duplicated from packer for deciding which device to use - we are now able to allow packer to pick the device on its own, which should be much more reliable.

# Known issues

The grsecurity kernel has a problem where it exposes the root device as 'sda1' instead of "xvda1" this confuses packer, causing it to prefer to use the "sd" scheme instead of the "xvd" scheme. New devices are mounted as "xvdY", but packer thinks they are "sdY". This means we either need to:

* Fix the grsecurity kernel to report xvda as the root device
* Find a way to rename / force a name for the root device node
* Disable the grsecurity kernel
* patch / fix packer to understand grsecurity kernels

EDIT: I have a workaround https://github.com/Shopify/cookbooks/pull/13140

@dwradcliffe @stonith @lxfontes 

cc @wvanbergen @mutemule 