### PR TITLE
Increase to Standard storage class for S3, it's cheaper

### DIFF
--- a/lib/linecook-gem/image/s3.rb
+++ b/lib/linecook-gem/image/s3.rb
@@ -39,7 +39,7 @@ module Linecook
         fid = File.basename(path)
         pbar = ProgressBar.create(title: fid, total: file.size)
         common_opts = { bucket: Linecook.config[:aws][:s3][:bucket], key: File.join([PREFIX, group, fid].compact) }
-        resp = client.create_multipart_upload(storage_class: 'REDUCED_REDUNDANCY', server_side_encryption: 'AES256', **common_opts)
+        resp = client.create_multipart_upload(storage_class: 'STANDARD', server_side_encryption: 'AES256', **common_opts)
         id = resp.upload_id
         part = 0
         total = 0


### PR DESCRIPTION
Reduced Redundancy storage is fractionally more expensive for less long-term storage reliability SLAs, Standard Redundancy should be better overall.

@dalehamel @dwradcliffe 