### PR TITLE
More fool-proof way of linkified resolvconf

### DIFF
--- a/lib/linecook-gem/packager/packer.rb
+++ b/lib/linecook-gem/packager/packer.rb
@@ -61,7 +61,10 @@ module Linecook
       'update-grub',
       'rm -f /etc/init/fake-container-events.conf', # HACK
       'mkdir -p /run/resolvconf/interface',
-      'DEBIAN_FRONTEND=noninteractive dpkg-reconfigure resolvconf' # re-linkify resolvconf
+      'echo "resolvconf resolvconf/linkify-resolvconf   boolean true" | debconf-set-selections', # write debconf
+      'dpkg-reconfigure -f noninteractive resolvconf', # re-linkify resolvconf
+      'truncate --size 0 /etc/resolv.conf', # clear build resolvconf config
+      'truncate --size 0 /etc/resolvconf/resolv.conf.d/original' # clear build resolvconf config
     ]
 
     def initialize(config)


### PR DESCRIPTION
Ensure that resolvconf is properly linkified, and does not use cached resolvconf from build host

Previously it was possible for debconf to not be in 'linkified mode'.

This forces it to be so, and truncates any possibly cached files that would store the state from the build host.

Upon booting, the default behavior is then to use DHCP to receive resolver information.